### PR TITLE
Исправлена проверка доступности серверов

### DIFF
--- a/php/actions/check_mirror_access.php
+++ b/php/actions/check_mirror_access.php
@@ -81,4 +81,4 @@ while (true) {
 curl_close($ch);
 
 // отправляем ответ
-echo $http_code == 200 ? '1' : '0';
+echo strpos($data, "Location: " . $url) === false ? '0' : '1';


### PR DESCRIPTION
Для определения доступности rutracker серверов недостаточно проверять `$http_code`,
т.к. заглушка провайдера тоже возвращает `$http_code == 200`.
Предлагаю воспользоваться тем, что запрос всегда переадресуется на страницу по умолчанию того же сервера.
Например, при запросе к https://api.t-ru.org происходит переадресация на https://api.t-ru.org/v1/docs/ :

```
HTTP/1.1 200 Connection established

HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Tue, 13 Nov 2018 22:00:02 GMT
Content-Type: text/html
Content-Length: 178
Location: https://api.t-ru.org/v1/docs/
Connection: keep-alive

HTTP/1.1 200 OK
Server: nginx
Date: Tue, 13 Nov 2018 22:00:02 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 3809
Last-Modified: Tue, 26 Sep 2017 16:21:30 GMT
Connection: keep-alive
Vary: Accept-Encoding
ETag: "59ca7e8a-ee1"
Accept-Ranges: bytes 
```