### PR TITLE
Fix short search string in search_topic_id

### DIFF
--- a/php/classes/reports.php
+++ b/php/classes/reports.php
@@ -103,7 +103,7 @@ class Reports
         }
         $title = html_entity_decode($title);
         $search = preg_replace('/.*» ?(.*)$/', '$1', $title);
-        if (mb_strlen($search, 'UTF-8') < 3) {
+        if (mb_strlen($search, 'UTF-8') < 2) {
             return false;
         }
         $title = explode(' » ', $title);


### PR DESCRIPTION
Исправлена ошибка `Error: Не удалось найти тему со списком для подраздела № 908` для подраздела `Игры » Игры для консолей » PS`.
Длина $search всего 2 символа для этого раздела.