### PR TITLE
[fix] rTorrent Error: Wrong object type.

### DIFF
--- a/php/classes/rtorrent.php
+++ b/php/classes/rtorrent.php
@@ -205,7 +205,7 @@ class Rtorrent extends TorrentClient
                     array(
                         array(
                             'methodName' => 'd.custom5.set',
-                            'params' => array($torrentHash, 1),
+                            'params' => array($torrentHash, '1'),
                         ),
                         array(
                             'methodName' => 'd.delete_tied',


### PR DESCRIPTION
Исправлена ошибка rTorrent Error: Wrong object type.
Fixes #111. 