### PR TITLE
Fix UI sorter

### DIFF
--- a/src/scripts/jquery.common.js
+++ b/src/scripts/jquery.common.js
@@ -11,18 +11,6 @@ const compareByLocale = (a, b) =>
     COLLATOR_EN.compare(a, b) ||
     COLLATOR_RU.compare(a, b);
 
-/* текущее время */
-function nowTime() {
-    var now = new Date();
-    var day = (now.getDate() < 10 ? "0" : "") + now.getDate();
-    var month = (parseInt(now.getMonth() + 1) < 10 ? "0" : "") + parseInt(now.getMonth() + 1);
-    var year = now.getFullYear();
-    var hours = (now.getHours() < 10 ? "0" : "") + now.getHours();
-    var minutes = (now.getMinutes() < 10 ? "0" : "") + now.getMinutes();
-    var seconds = (now.getSeconds() < 10 ? "0" : "") + now.getSeconds();
-    return day + "." + month + "." + year + " " + hours + ":" + minutes + ":" + seconds + " ";
-}
-
 /* перевод байт */
 function convertBytes(size) {
     var filesizename = [" Bytes", " KB", " MB", " GB", " TB", " PB", " EB", " ZB", " YB"];
@@ -132,19 +120,6 @@ function doSortSelect(selectId, sortElement = 'option') {
     });
 
     $select.empty().append(sorted);
-}
-
-function doSortSelectByValue(selectID, sortElement = "option") {
-    $("#" + selectID).toggle();
-    var sortedVals = $.makeArray($("#" + selectID + " " + sortElement)).sort(function (a, b) {
-        if ($(a).val() == 0) {
-            return -1;
-        }
-        var textA = $(a).text().toUpperCase();
-        var textB = $(b).text().toUpperCase();
-        return textA.localeCompare(textB, undefined, { numeric: true, sensitivity: "base" });
-    });
-    $("#" + selectID).empty().html(sortedVals).toggle();
 }
 
 // сохранение настроек


### PR DESCRIPTION
Сортировка строк в UI не учитывает два языка и по сути сортирует только "текущую" локаль, т.е. RU.
Добавил двойную сортировку EN -> RU.

Fix #477 