### PR TITLE
Скорректировано форматирование журнала

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -35,7 +35,7 @@ try {
 } catch (Exception $e) {
     echo '<b>Запуск невозможен.</b><br>';
     echo 'Ошибка запуска программы. <br>';
-    echo htmlspecialchars($e->getMessage()) . '<br>';
+    echo Render::escape($e->getMessage()) . '<br>';
 
     echo '<br><b>Логи:</b><br>';
     echo Log::getRecords();

--- a/src/back/Front/Render.php
+++ b/src/back/Front/Render.php
@@ -53,6 +53,18 @@ final class Render
     ) {}
 
     /**
+     * Экранируем значения для html.
+     */
+    public static function escape(null|int|string $value): string
+    {
+        if (empty($value)) {
+            return '';
+        }
+
+        return htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function getConfig(): array
@@ -295,17 +307,5 @@ final class Render
     private static function makeDatasetTemplate(array $keys): string
     {
         return implode(' ', array_map(static fn($el) => "data-$el=\"%s\"", $keys));
-    }
-
-    /**
-     * Экранируем значения для html.
-     */
-    private static function escape(null|int|string $value): string
-    {
-        if (empty($value)) {
-            return '';
-        }
-
-        return htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
     }
 }

--- a/src/back/Logger/MemoryLoggerHandler.php
+++ b/src/back/Logger/MemoryLoggerHandler.php
@@ -33,7 +33,7 @@ final class MemoryLoggerHandler extends AbstractProcessingHandler implements Han
     public static function getRecords(string $break = '<br />'): string
     {
         if (count(self::$records)) {
-            $formatted = self::formatRows(rows: self::$records, break: $break);
+            $formatted = self::formatRows(rows: self::$records, break: $break, replace: true);
 
             self::$records = [];
 


### PR DESCRIPTION
Скорректировано экранирование спецсимволов при выводе журнала на вкладке Журнал->Лог. 
Ранее ошибки выводились как есть, со всем форматированием, что превращало содержимое в кашу.

Частично основано на #474